### PR TITLE
Add partytown integration and setup Vercel Web Analytics & Speed Insights

### DIFF
--- a/apps/blog/astro.config.ts
+++ b/apps/blog/astro.config.ts
@@ -36,11 +36,17 @@ export default defineConfig({
   },
   integrations: [
     react(),
-    tailwind({ applyBaseStyles: false }),
+    tailwind({
+      applyBaseStyles: false,
+    }),
     readingTime(),
     mdx(),
+    partytown({
+      config: {
+        forward: ["si", "siq.push", "va", "vaq.push"],
+      },
+    }),
     sitemap(),
-    partytown(),
   ],
   prefetch: true,
 });

--- a/apps/blog/astro.config.ts
+++ b/apps/blog/astro.config.ts
@@ -5,6 +5,7 @@ import tailwind from "@astrojs/tailwind";
 import readingTime from "astro-reading-time";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
+import partytown from "@astrojs/partytown";
 
 import emoji from "remark-emoji";
 import mermaid from "rehype-mermaid";
@@ -39,6 +40,7 @@ export default defineConfig({
     readingTime(),
     mdx(),
     sitemap(),
+    partytown(),
   ],
   prefetch: true,
 });

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@astrojs/check": "^0.5.6",
     "@astrojs/mdx": "^2.1.1",
+    "@astrojs/partytown": "^2.0.4",
     "@astrojs/react": "^3.0.10",
     "@astrojs/rss": "^4.0.5",
     "@astrojs/sitemap": "^3.1.1",

--- a/apps/blog/src/layouts/base-layout.astro
+++ b/apps/blog/src/layouts/base-layout.astro
@@ -26,20 +26,41 @@ type Props = { head?: HeadProps } & HTMLAttributes<"body">;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{meta.title}</title>
+    <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&display=swap"
       rel="stylesheet"
     />
+    <!-- Vercel Web Analytics & Speed Insights -->
+    {
+      import.meta.env.PROD ? (
+        <>
+          <script
+            src="/_vercel/speed-insights/script.js"
+            type="text/partytown"
+          />
+          <script src="/_vercel/insights/script.js" type="text/partytown" />
+        </>
+      ) : (
+        <script
+          src="https://cdn.vercel-insights.com/v1/script.debug.js"
+          type="text/partytown"
+        />
+      )
+    }
+    <!-- Website Metadata -->
     <meta name="theme-color" content="#e76e50" />
     <meta name="description" content={meta.description} />
     <meta name="author" content={siteConfig.author} />
     <meta name="keywords" content={meta.keywords} />
+    <!-- Open Graph / Facebook -->
     <meta property="og:title" content={meta.title} />
     <meta property="og:description" content={meta.description} />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content={siteConfig.title} />
+    <!-- Favicons -->
     <meta name="msapplication-config" content="browserconfig.xml" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <meta name="msapplication-TileColor" content="#000000" />

--- a/apps/blog/src/layouts/base-layout.astro
+++ b/apps/blog/src/layouts/base-layout.astro
@@ -75,6 +75,7 @@ type Props = { head?: HeadProps } & HTMLAttributes<"body">;
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
     <link rel="mask-icon" href="/images/safari-tab.svg" color="#4c4c4c" />
     <link rel="manifest" href="/site.webmanifest" />
+    <!-- Astro Bundler -->
   </head>
   <body
     class={cn(

--- a/apps/blog/src/layouts/base-layout.astro
+++ b/apps/blog/src/layouts/base-layout.astro
@@ -11,6 +11,7 @@ const meta = {
   description: head?.description ?? siteConfig.description,
   keywords: [siteConfig.keywords, ...(head?.keywords ?? [])].join(", "),
   author: siteConfig.author,
+  url: new URL(Astro.url.pathname, import.meta.env.SITE),
 };
 
 export type HeadProps = {
@@ -58,8 +59,14 @@ type Props = { head?: HeadProps } & HTMLAttributes<"body">;
     <!-- Open Graph / Facebook -->
     <meta property="og:title" content={meta.title} />
     <meta property="og:description" content={meta.description} />
-    <meta property="og:type" content="website" />
     <meta property="og:site_name" content={siteConfig.title} />
+    <meta property="og:url" content={meta.url} />
+    <meta property="og:type" content="website" />
+    <!-- Twitter -->
+    <meta property="twitter:title" content={meta.title} />
+    <meta property="twitter:description" content={meta.description} />
+    <meta property="twitter:url" content={meta.url} />
+    <meta property="twitter:card" content="summary_large_image" />
     <!-- Favicons -->
     <meta name="msapplication-config" content="browserconfig.xml" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^2.1.1
         version: 2.1.1(astro@4.4.6)
+      '@astrojs/partytown':
+        specifier: ^2.0.4
+        version: 2.0.4
       '@astrojs/react':
         specifier: ^3.0.10
         version: 3.0.10(@types/react-dom@18.2.19)(@types/react@18.2.60)(react-dom@18.2.0)(react@18.2.0)(vite@5.1.4)
@@ -380,6 +383,13 @@ packages:
       - supports-color
     dev: false
 
+  /@astrojs/partytown@2.0.4:
+    resolution: {integrity: sha512-yC1smFLOBn7CWNAzaigXAr4bSJSgRJYF4g9jDuSR0NbShLd1SVUpRm9QOmOIrfSFGh2YtZEW8gnwvI5SZw+WmA==}
+    dependencies:
+      '@builder.io/partytown': 0.8.2
+      mrmime: 1.0.1
+    dev: false
+
   /@astrojs/prism@3.0.0:
     resolution: {integrity: sha512-g61lZupWq1bYbcBnYZqdjndShr/J3l/oFobBKPA3+qMat146zce3nz2kdO4giGbhYDt4gYdhmoBz0vZJ4sIurQ==}
     engines: {node: '>=18.14.1'}
@@ -683,6 +693,12 @@ packages:
 
   /@braintree/sanitize-url@6.0.4:
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
+    dev: false
+
+  /@builder.io/partytown@0.8.2:
+    resolution: {integrity: sha512-WKGE+SO0qUGirW8J+xOWkHeCkfFEoPPvHnFkcdMl+MY3kDbAcTwjZCzjg27JCvoD0h8fH47FR7DSIss0/S5lyg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
     dev: false
 
   /@changesets/apply-release-plan@7.0.0:
@@ -5203,6 +5219,11 @@ packages:
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+    dev: false
+
+  /mrmime@1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
     dev: false
 
   /ms@2.1.2:


### PR DESCRIPTION
This pull request adds the partytown integration to the project and sets up Vercel Web Analytics & Speed Insights. The partytown integration allows for forwarding of specific events to external services, while Vercel Web Analytics & Speed Insights provide performance and analytics tracking for the website.