### PR TITLE
Refactor font loading and API routes

### DIFF
--- a/apps/blog/src/pages/og.png.ts
+++ b/apps/blog/src/pages/og.png.ts
@@ -2,8 +2,9 @@ import { createElement } from "react";
 import { OgTemplate } from "@/components/og-templates/home";
 import { ImageResponse } from "@vercel/og";
 import { loadFonts } from "@/utils";
+import type { APIRoute } from "astro";
 
-export async function GET() {
+export const GET: APIRoute = async () => {
   try {
     return new ImageResponse(createElement(OgTemplate), {
       fonts: [
@@ -22,4 +23,4 @@ export async function GET() {
       status: 500,
     });
   }
-}
+};

--- a/apps/blog/src/pages/og.png.ts
+++ b/apps/blog/src/pages/og.png.ts
@@ -1,8 +1,7 @@
 import { createElement } from "react";
 import { OgTemplate } from "@/components/og-templates/home";
 import { ImageResponse } from "@vercel/og";
-import path from "node:path";
-import fs from "node:fs/promises";
+import { loadFonts } from "@/utils";
 
 export async function GET() {
   try {
@@ -24,11 +23,3 @@ export async function GET() {
     });
   }
 }
-
-const loadFonts = async () => {
-  return {
-    pacifico: await fs.readFile(
-      path.resolve("./public/fonts/pacifico/Pacifico-Regular.ttf"),
-    ),
-  };
-};

--- a/apps/blog/src/pages/posts/[...slug]/og.png.ts
+++ b/apps/blog/src/pages/posts/[...slug]/og.png.ts
@@ -1,13 +1,17 @@
 import { createElement } from "react";
 import { OgTemplate } from "@/components/og-templates/post";
 import { ImageResponse } from "@vercel/og";
-import { getCollection } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import { loadFonts } from "@/utils";
-import type { GetStaticPaths } from "astro";
+import type { GetStaticPaths, APIRoute } from "astro";
 
-export async function GET({ props: { entry } }: Props) {
+export const GET: APIRoute<{
+  entry: CollectionEntry<"posts">;
+}> = async ({ props: { entry } }) => {
+  const html = createElement(OgTemplate, { data: entry.data });
+
   try {
-    return new ImageResponse(createElement(OgTemplate, { data: entry.data }), {
+    return new ImageResponse(html, {
       fonts: [
         {
           name: "SmileySans",
@@ -24,7 +28,7 @@ export async function GET({ props: { entry } }: Props) {
       status: 500,
     });
   }
-}
+};
 
 export const getStaticPaths = (async () => {
   const entries = await getCollection("posts");
@@ -33,5 +37,3 @@ export const getStaticPaths = (async () => {
     props: { entry },
   }));
 }) satisfies GetStaticPaths;
-
-type Props = Awaited<ReturnType<typeof getStaticPaths>>[number];

--- a/apps/blog/src/pages/posts/[...slug]/og.png.ts
+++ b/apps/blog/src/pages/posts/[...slug]/og.png.ts
@@ -2,8 +2,7 @@ import { createElement } from "react";
 import { OgTemplate } from "@/components/og-templates/post";
 import { ImageResponse } from "@vercel/og";
 import { getCollection } from "astro:content";
-import path from "node:path";
-import fs from "node:fs/promises";
+import { loadFonts } from "@/utils";
 import type { GetStaticPaths } from "astro";
 
 export async function GET({ props: { entry } }: Props) {
@@ -26,14 +25,6 @@ export async function GET({ props: { entry } }: Props) {
     });
   }
 }
-
-const loadFonts = async () => {
-  return {
-    smileySans: await fs.readFile(
-      path.resolve("./public/fonts/smiley-sans/SmileySans-Oblique.ttf"),
-    ),
-  };
-};
 
 export const getStaticPaths = (async () => {
   const entries = await getCollection("posts");

--- a/apps/blog/src/pages/rss.xml.ts
+++ b/apps/blog/src/pages/rss.xml.ts
@@ -2,9 +2,9 @@ import rss from "@astrojs/rss";
 import { siteConfig } from "@/config";
 import { getCollection } from "astro:content";
 import { getTime } from "date-fns";
-import type { APIContext } from "astro";
+import type { APIRoute } from "astro";
 
-export async function GET(context: APIContext) {
+export const GET: APIRoute = async (context) => {
   const { author, title, description } = siteConfig;
   const blogs = (
     await getCollection("posts", ({ data }) => {
@@ -27,4 +27,4 @@ export async function GET(context: APIContext) {
     })),
     stylesheet: "/rss/pretty-feed-v3.xsl",
   });
-}
+};

--- a/apps/blog/src/utils.ts
+++ b/apps/blog/src/utils.ts
@@ -1,6 +1,45 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import path from "node:path";
+import fs from "node:fs/promises";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const memoize: {
+  <T, F extends (...args: any[]) => T>(
+    fn: F,
+    hasher?: (...args: Parameters<F>) => any,
+  ): F & { cache: Map<any, T> };
+  Cache: MapConstructor;
+} = function (fn, hasher) {
+  const memoized = function (this: any, ...args: any) {
+    const keys = hasher ? hasher.apply(this, args) : args[0];
+    const cache = memoized.cache;
+
+    if (!cache.has(keys)) {
+      memoized.cache = cache.set(keys, fn.apply(this, args));
+    }
+
+    return cache.get(keys);
+  };
+  memoized.cache = new (memoize.Cache || Map)();
+
+  return memoized as any;
+};
+memoize.Cache = Map;
+
+export const loadFonts = memoize(
+  async () => {
+    return {
+      pacifico: await fs.readFile(
+        path.resolve("./public/fonts/pacifico/Pacifico-Regular.ttf"),
+      ),
+      smileySans: await fs.readFile(
+        path.resolve("./public/fonts/smiley-sans/SmileySans-Oblique.ttf"),
+      ),
+    };
+  },
+  () => "fonts",
+);


### PR DESCRIPTION
This pull request includes two commits:

- refactor: re-implement font loading with memoization

- refactor: rewrite API routes in `og.png.ts` and `rss.xml.ts`