### PR TITLE
Optimize blog post sorting, navigation, and components

### DIFF
--- a/apps/blog/src/components/arrow-link.astro
+++ b/apps/blog/src/components/arrow-link.astro
@@ -1,6 +1,7 @@
 ---
 import Link from "@/components/site-nav-item.astro";
 import { FaArrowLeftLong, FaArrowRightLong } from "react-icons/fa6";
+import { cn } from "@/utils";
 import type { ComponentProps } from "astro/types";
 
 const { label, ...props } = Astro.props;
@@ -12,10 +13,18 @@ type Props = {
 ---
 
 <div
-  class="flex w-full flex-col justify-between py-1 md:flex-row md:items-center"
+  class={cn(
+    "flex w-full flex-col justify-between py-1 md:flex-row md:items-center",
+    label === "prev" ? "items-start" : "items-end",
+  )}
 >
   <span>{label === "prev" ? "Previous article" : "Next article"}</span>
-  <div class="flex flex-row items-center justify-start gap-2">
+  <div
+    class={cn(
+      "flex items-center gap-2 justify-start md:flex-row",
+      label === "prev" ? "flex-row-reverse" : "flex-row",
+    )}
+  >
     <Link class="flex-1" {...props}><slot /></Link>
     <Icon className="h-4 w-4 animate-pulse" />
   </div>

--- a/apps/blog/src/components/vercel-insights.astro
+++ b/apps/blog/src/components/vercel-insights.astro
@@ -1,0 +1,4 @@
+<script src="/_vercel/speed-insights/script.js" type="text/partytown" is:inline
+></script>
+<script src="/_vercel/insights/script.js" type="text/partytown" is:inline
+></script>

--- a/apps/blog/src/layouts/base-layout.astro
+++ b/apps/blog/src/layouts/base-layout.astro
@@ -1,6 +1,7 @@
 ---
 import "@/styles/globals.css";
 
+import VercelInsights from "@/components/vercel-insights.astro";
 import { siteConfig } from "@/config";
 import { cn } from "@/utils";
 import type { HTMLAttributes } from "astro/types";
@@ -30,22 +31,7 @@ type Props = { head?: HeadProps } & HTMLAttributes<"body">;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{meta.title}</title>
     <!-- Vercel Web Analytics & Speed Insights -->
-    {
-      import.meta.env.PROD ? (
-        <>
-          <script
-            src="/_vercel/speed-insights/script.js"
-            type="text/partytown"
-          />
-          <script src="/_vercel/insights/script.js" type="text/partytown" />
-        </>
-      ) : (
-        <script
-          src="https://cdn.vercel-insights.com/v1/script.debug.js"
-          type="text/partytown"
-        />
-      )
-    }
+    {import.meta.env.PROD && <VercelInsights />}
     <!-- Favicons -->
     <meta name="msapplication-config" content="browserconfig.xml" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -1,16 +1,14 @@
 ---
 import Layout from "@/layouts/home-layout.astro";
 import PostIndex from "@/components/post-index.astro";
-import { getCollection } from "astro:content";
+import { getEntries } from "@/utils";
 import { getTime } from "date-fns";
 import { AiFillHeart } from "react-icons/ai";
 import { LuRss } from "react-icons/lu";
 
-const blogs = (
-  await getCollection("posts", ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true;
-  })
-).sort(({ data: a }, { data: b }) => getTime(b.date) - getTime(a.date));
+const blogs = (await getEntries()).sort(
+  ({ data: a }, { data: b }) => getTime(b.date) - getTime(a.date),
+);
 ---
 
 <Layout>

--- a/apps/blog/src/pages/posts/[...slug]/index.astro
+++ b/apps/blog/src/pages/posts/[...slug]/index.astro
@@ -5,20 +5,18 @@ import Horizontal from "@/components/mdx/hr.astro";
 import Image from "@/components/mdx/img.astro";
 import Preformatted from "@/components/mdx/pre.astro";
 import ArrowLink from "@/components/arrow-link.astro";
-import { getCollection } from "astro:content";
+import { getEntries } from "@/utils";
 import type { GetStaticPaths } from "astro";
 
 export const getStaticPaths = (async () => {
-  const entries = await getCollection("posts");
-  return entries.map((entry, i, arr) => {
-    const prev = arr[i - 1] ?? null;
-    const next = arr[i + 1] ?? null;
-
-    return {
-      params: { slug: entry.slug },
-      props: { entry, prev, next },
-    };
-  });
+  return (await getEntries()).map((entry, i, entries) => ({
+    params: { slug: entry.slug },
+    props: {
+      prev: entries[i - 1] ?? null,
+      next: entries[i + 1] ?? null,
+      entry,
+    },
+  }));
 }) satisfies GetStaticPaths;
 
 const { entry, prev, next } = Astro.props;

--- a/apps/blog/src/pages/posts/[...slug]/og.png.ts
+++ b/apps/blog/src/pages/posts/[...slug]/og.png.ts
@@ -1,8 +1,8 @@
 import { createElement } from "react";
 import { OgTemplate } from "@/components/og-templates/post";
 import { ImageResponse } from "@vercel/og";
-import { getCollection, type CollectionEntry } from "astro:content";
-import { loadFonts } from "@/utils";
+import { loadFonts, getEntries } from "@/utils";
+import type { CollectionEntry } from "astro:content";
 import type { GetStaticPaths, APIRoute } from "astro";
 
 export const GET: APIRoute<{
@@ -31,8 +31,7 @@ export const GET: APIRoute<{
 };
 
 export const getStaticPaths = (async () => {
-  const entries = await getCollection("posts");
-  return entries.map((entry) => ({
+  return (await getEntries()).map((entry) => ({
     params: { slug: entry.slug },
     props: { entry },
   }));

--- a/apps/blog/src/pages/rss.xml.ts
+++ b/apps/blog/src/pages/rss.xml.ts
@@ -1,18 +1,14 @@
 import rss from "@astrojs/rss";
 import { siteConfig } from "@/config";
-import { getCollection } from "astro:content";
+import { getEntries } from "@/utils";
 import { getTime } from "date-fns";
 import type { APIRoute } from "astro";
 
 export const GET: APIRoute = async (context) => {
   const { author, title, description } = siteConfig;
-  const blogs = (
-    await getCollection("posts", ({ data }) => {
-      return import.meta.env.PROD ? data.draft !== true : true;
-    })
-  ).sort(({ data: a }, { data: b }) => {
-    return getTime(b.date) - getTime(a.date);
-  });
+  const blogs = (await getEntries()).sort(
+    ({ data: a }, { data: b }) => getTime(b.date) - getTime(a.date),
+  );
 
   return rss({
     title: title,

--- a/apps/blog/src/pages/tags/[...tag]/index.astro
+++ b/apps/blog/src/pages/tags/[...tag]/index.astro
@@ -2,17 +2,14 @@
 import Layout from "@/layouts/common-layout.astro";
 import PostIndex from "@/components/post-index.astro";
 import Icon from "@/components/ui/icon.astro";
-import { getCollection, type CollectionEntry } from "astro:content";
 import { getTime } from "date-fns";
 import { slug } from "github-slugger";
+import { getEntries } from "@/utils";
+import type { CollectionEntry } from "astro:content";
 import type { GetStaticPaths } from "astro";
 
 export const getStaticPaths = (async () => {
-  const tagsWithPosts = (
-    await getCollection("posts", ({ data }) => {
-      return import.meta.env.PROD ? data.draft !== true : true;
-    })
-  )
+  const tagsWithPosts = (await getEntries())
     .sort(({ data: a }, { data: b }) => getTime(b.date) - getTime(a.date))
     .reduce<Record<string, CollectionEntry<"posts">[]>>((acc, entry) => {
       entry.data.tags?.forEach((tag) => {

--- a/apps/blog/src/pages/tags/index.astro
+++ b/apps/blog/src/pages/tags/index.astro
@@ -2,21 +2,20 @@
 import Layout from "@/layouts/common-layout.astro";
 import Button from "@/components/ui/button.astro";
 import Icon from "@/components/ui/icon.astro";
-import { getCollection } from "astro:content";
+import { getEntries } from "@/utils";
 import { slug } from "github-slugger";
 import { LuTags } from "react-icons/lu";
 
-const tagsWithCount = (
-  await getCollection("posts", ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true;
-  })
-).reduce<Record<string, number>>((acc, { data: { tags } }) => {
-  tags?.forEach((tag) => {
-    acc[tag] = (acc[tag] ?? 0) + 1;
-  });
+const tagsWithCount = (await getEntries()).reduce<Record<string, number>>(
+  (acc, { data: { tags } }) => {
+    tags?.forEach((tag) => {
+      acc[tag] = (acc[tag] ?? 0) + 1;
+    });
 
-  return acc;
-}, {});
+    return acc;
+  },
+  {},
+);
 ---
 
 <Layout title="Tags" keywords={Object.keys(tagsWithCount)}>

--- a/apps/blog/src/utils.ts
+++ b/apps/blog/src/utils.ts
@@ -2,6 +2,7 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import path from "node:path";
 import fs from "node:fs/promises";
+import { getCollection } from "astro:content";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -43,3 +44,9 @@ export const loadFonts = memoize(
   },
   () => "fonts",
 );
+
+export async function getEntries() {
+  return await getCollection("posts", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+}


### PR DESCRIPTION
Refactor the code to optimize the sorting and navigation of blog posts. This includes using the new getEntries function for retrieving blog posts, which reduces the number of API calls and improves performance. Additionally, the arrow-link component has been optimized for better article navigation by adding previous and next links. The Vercel Web Analytics and Speed Insights components have also been split into independent components for better modularity.