### PR TITLE
Update Vercel deployment commands and fix issues

### DIFF
--- a/.github/workflows/mono-build.yml
+++ b/.github/workflows/mono-build.yml
@@ -34,8 +34,9 @@ jobs:
           restore-keys: ${{ runner.os }}-ms-playwright-
           path: /home/runner/.cache/ms-playwright
       - run: pnpm install --global vercel@latest
-      - run: vercel login --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel pull --yes --environment=preview
-      - run: vercel | xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
+      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - run: |
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | \
+          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
         id: deployment
-      - run: vercel logout

--- a/.github/workflows/mono-build.yml
+++ b/.github/workflows/mono-build.yml
@@ -38,5 +38,5 @@ jobs:
       - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - run: |
           vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | \
-          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
+          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_OUTPUT}"
         id: deployment

--- a/.github/workflows/mono-build.yml
+++ b/.github/workflows/mono-build.yml
@@ -34,10 +34,8 @@ jobs:
           restore-keys: ${{ runner.os }}-ms-playwright-
           path: /home/runner/.cache/ms-playwright
       - run: pnpm install --global vercel@latest
-      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - run: |
-          DEPLOYMENT_URL=$(mktemp --suffix ".deployment-url.txt")
-          vercel --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > "${DEPLOYMENT_URL}"
-          echo "DEPLOYMENT_URL=$(cat ${DEPLOYMENT_URL})" >> "${GITHUB_OUTPUT}"
+      - run: vercel login --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel pull --yes --environment=preview
+      - run: vercel | xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
         id: deployment
+      - run: vercel logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - run: |
           vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} | \
-          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
+          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_OUTPUT}"
         id: deployment
       - name: Create Version PR or Publish to NPM
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,11 @@ jobs:
           restore-keys: ${{ runner.os }}-ms-playwright-
           path: /home/runner/.cache/ms-playwright
       - run: pnpm install --global vercel@latest
-      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - run: |
-          DEPLOYMENT_URL=$(mktemp --suffix ".deployment-url.txt")
-          vercel --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} > "${DEPLOYMENT_URL}"
-          echo "DEPLOYMENT_URL=$(cat ${DEPLOYMENT_URL})" >> "${GITHUB_OUTPUT}"
+      - run: vercel login --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel pull --yes --environment=production
+      - run: vercel --prod | xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
         id: deployment
+      - run: vercel logout
       - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1.4.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,12 @@ jobs:
           restore-keys: ${{ runner.os }}-ms-playwright-
           path: /home/runner/.cache/ms-playwright
       - run: pnpm install --global vercel@latest
-      - run: vercel login --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel pull --yes --environment=production
-      - run: vercel --prod | xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
+      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - run: |
+          vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} | \
+          xargs -I {} echo "DEPLOYMENT_URL={}" >> "${GITHUB_ENV}"
         id: deployment
-      - run: vercel logout
       - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1.4.7


### PR DESCRIPTION
This pull request updates the Vercel deployment commands in the mono-build.yml and release.yml workflows to improve the deployment process. The changes include replacing the vercel build command with vercel --prod in the release.yml workflow, updating the vercel pull command to remove the --token flag in both workflows, adding a vercel login command before the vercel pull command in both workflows, using xargs and echo to set the DEPLOYMENT_URL environment variable in the mono-build.yml workflow, and adding a vercel logout command at the end of both workflows. Additionally, this pull request fixes the issue where `--token` may not be used with the "login" command and the issue with the wrong output file. These changes aim to streamline the deployment process and ensure the correct environment variables are set for the deployments.