### PR TITLE
Update middleware to export a function to create app jwt

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -45,7 +45,8 @@
     "remark-emoji": "^5.0.0",
     "tailwind-merge": "^2.4.0",
     "tailwindcss": "^3.4.5",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "universal-github-app-jwt": "^2.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/apps/blog/src/env.d.ts
+++ b/apps/blog/src/env.d.ts
@@ -15,8 +15,9 @@ interface ImportMeta {
 
 declare namespace App {
   interface Locals {
-    user?: {
-      token: string;
+    user: {
+      token?: string;
     };
+    getAppJWT: () => Promise<string>;
   }
 }

--- a/apps/blog/src/env.d.ts
+++ b/apps/blog/src/env.d.ts
@@ -15,9 +15,9 @@ interface ImportMeta {
 
 declare namespace App {
   interface Locals {
-    user: {
+    user?: {
       token?: string;
     };
-    getAppJWT: () => Promise<string>;
+    getAppToken: () => Promise<string>;
   }
 }

--- a/apps/blog/src/middleware.ts
+++ b/apps/blog/src/middleware.ts
@@ -1,26 +1,47 @@
 import { decrypt } from "@mogeko/utils/ase-gcm";
+import githubAppJwt, { type Result } from "universal-github-app-jwt";
 import { getSecret } from "astro:env/server";
-import { defineMiddleware } from "astro:middleware";
+import { defineMiddleware, sequence } from "astro:middleware";
 
-export const onRequest = defineMiddleware(
-  async ({ url, cookies, locals }, next) => {
-    try {
-      // It will print a 'WARN' message when generating static pages. It's a known issue.
-      // In order to alleviate this issue, we only decrypt the cookie when the URL pathname
-      // matches `/posts/*`.
-      // See: https://github.com/withastro/docs/issues/7215
-      if (/^\/posts\/.+/.test(url.pathname) && cookies.has("oauth_token")) {
-        const cookie = cookies.get("oauth_token")?.value;
-        const passwd = getSecret("ENCRYPTION_PASSWD");
+export const onRequest = sequence(
+  defineMiddleware(async ({ locals }, next) => {
+    const privateKey = getSecret("APP_PRIVATE_KEY");
+    const clientID = getSecret("OAUTH_CLIENT_ID");
 
-        if (passwd && cookie) {
-          const { value } = JSON.parse(await decrypt(cookie, passwd));
-
-          locals.user = { token: value };
-        }
-      }
-    } finally {
-      return next();
+    if (clientID && privateKey) {
+      locals.getAppJWT = ((cache?: Result<string>) => {
+        return async () => {
+          if (!cache || cache.expiration < Date.now()) {
+            cache = await githubAppJwt({ id: clientID, privateKey });
+          }
+          return cache.token;
+        };
+      })(void 0);
+    } else {
+      const ctx = JSON.stringify({ error: "Internal server error." });
+      return new Response(ctx, { status: 500 });
     }
-  },
+
+    return next();
+  }),
+  defineMiddleware(async ({ url, cookies, locals }, next) => {
+    // It will print a 'WARN' message when generating static pages. It's a known issue.
+    // In order to alleviate this issue, we only decrypt the cookie when the URL pathname
+    // matches `/posts/*`.
+    // See: https://github.com/withastro/docs/issues/7215
+    if (/^\/posts\/.+/.test(url.pathname) && cookies.has("oauth_token")) {
+      const cookie = cookies.get("oauth_token")?.value;
+      const passwd = getSecret("ENCRYPTION_PASSWD");
+
+      if (cookie && passwd) {
+        const oauthToken = JSON.parse(
+          await decrypt(cookie, passwd).catch((_) => "{}"),
+        ).value;
+
+        locals.user = { token: oauthToken };
+      }
+    }
+
+    return next();
+  }),
 );

--- a/apps/blog/src/middleware.ts
+++ b/apps/blog/src/middleware.ts
@@ -1,21 +1,43 @@
+import githubAppJwt from "universal-github-app-jwt";
+import { isPast } from "date-fns";
 import { decrypt } from "@mogeko/utils/ase-gcm";
-import githubAppJwt, { type Result } from "universal-github-app-jwt";
 import { getSecret } from "astro:env/server";
 import { defineMiddleware, sequence } from "astro:middleware";
 
+const createAppAuth: {
+  (pkcs8: string, cid: string, iid: string): App.Locals["getAppToken"];
+  cache?: { token: string; expiresAt: string };
+} = (pkcs8, cid, iid) => {
+  return async () => {
+    if (!createAppAuth.cache || isPast(createAppAuth.cache.expiresAt)) {
+      const jwt = await githubAppJwt({ id: cid, privateKey: pkcs8 });
+      const { token, expires_at } = await fetch(
+        `https://api.github.com/app/installations/${iid}/access_tokens`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${jwt.token}`,
+            Accept: "application/json",
+          },
+        },
+      ).then((resp) => resp.json());
+
+      createAppAuth.cache = { token, expiresAt: expires_at };
+    }
+
+    return createAppAuth.cache.token;
+  };
+};
+
 export const onRequest = sequence(
   defineMiddleware(async ({ locals }, next) => {
-    locals.getAppJWT = ((cache?: Result<string>) => {
-      const [pkcs8, id] = ["APP_PRIVATE_KEY", "OAUTH_CLIENT_ID"].map(getSecret);
+    const pkcs8 = getSecret("APP_PRIVATE_KEY");
+    const iid = getSecret("APP_INSTALLATIONS_ID");
+    const cid = getSecret("OAUTH_CLIENT_ID");
 
-      return async () => {
-        if (!pkcs8 || !id) throw new Error("Internal server error.");
-        if (!cache || cache.expiration < Date.now()) {
-          cache = await githubAppJwt({ id, privateKey: pkcs8 });
-        }
-        return cache.token;
-      };
-    })(void 0);
+    if (!pkcs8 || !cid || !iid) throw new Error("Internal server error.");
+
+    locals.getAppToken = createAppAuth(pkcs8, cid, iid);
 
     return next();
   }),

--- a/apps/blog/src/middleware.ts
+++ b/apps/blog/src/middleware.ts
@@ -9,9 +9,7 @@ export const onRequest = sequence(
     const iid = getSecret("APP_INSTALLATIONS_ID");
     const cid = getSecret("OAUTH_CLIENT_ID");
 
-    if (!pkcs8 || !cid || !iid) throw new Error("Internal server error.");
-
-    locals.getAppToken = createAppAuth({ pkcs8, cid, iid });
+    locals.getAppToken = createAppAuth(pkcs8, iid, cid);
 
     return next();
   }),

--- a/apps/blog/src/utils.ts
+++ b/apps/blog/src/utils.ts
@@ -37,10 +37,11 @@ export const getEntries = memoize(
 export type Entry = CollectionEntry<"posts">;
 
 export const createAppAuth: {
-  (arg: { pkcs8: string; cid: string; iid: string }): App.Locals["getAppToken"];
+  (pkcs8?: string, cid?: string, iid?: string): App.Locals["getAppToken"];
   cache?: { token: string; expiresAt: string };
-} = ({ pkcs8, cid, iid }) => {
+} = (pkcs8, iid, cid) => {
   return async () => {
+    if (!pkcs8 || !cid || !iid) throw new Error("Internal server error.");
     if (!createAppAuth.cache || isPast(createAppAuth.cache.expiresAt)) {
       const jwt = await githubAppJwt({ id: cid, privateKey: pkcs8 });
       const { token, expires_at } = await fetch(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.5)
+      universal-github-app-jwt:
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -3823,6 +3826,9 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  universal-github-app-jwt@2.2.0:
+    resolution: {integrity: sha512-G5o6f95b5BggDGuUfKDApKaCgNYy2x7OdHY0zSMF081O0EJobw+1130VONhrA7ezGSV2FNOGyM+KQpQZAr9bIQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -8335,6 +8341,8 @@ snapshots:
       '@types/unist': 3.0.2
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  universal-github-app-jwt@2.2.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
This pull request updates the middleware to export a function that creates an app JWT. It also throws an `Error` when `pkcs8` and `id` do not exist. Additionally, it updates the `getAppJWT` function to `getAppToken` in `env.d.ts` and `middleware.ts`. The `createAppAuth` function is refactored to accept an object argument in `middleware.ts` and `utils.ts`, and also to accept individual arguments. Finally, it merges the `dev` branch into `master`.