### PR TITLE
Update Dependabot auto-merge configuration and blog update rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: Automatic merge when release new versions
+    conditions:
+      - "title=chore(release): version packages"
+      - "commits=chore(release): version packages"
+      - "author=github-actions[bot]"
+      - "files~=CHANGELOG.md"
+      - "head~=changeset-release"
+    actions:
+      merge:
+
+  - name: Automatic label for blog updates
+    conditions:
+      - "files~=^apps/blog/"
+    actions:
+      label:
+        add: ["app:blog"]

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: PR Auto Merge
+name: Dependabot Auto Merge
 
 on: pull_request
 
@@ -11,16 +11,6 @@ jobs:
     name: Enable auto-merge for Dependabot PRs
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  changesets:
-    name: Enable auto-merge for Changesets PRs
-    runs-on: ubuntu-latest
-    if: github.head_ref == 'changeset-release/master'
     steps:
       - run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
Refine the auto-merge settings for Dependabot and establish automatic labeling for blog updates.