### PR TITLE
Revert auto-merge configuration updates for Dependabot and blog rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: Automatic merge when release new versions
+    conditions:
+      - "title=chore(release): version packages"
+      - "commits=chore(release): version packages"
+      - "author=github-actions[bot]"
+      - "files~=CHANGELOG.md"
+      - "head~=changeset-release"
+    actions:
+      merge:
+
+  - name: Automatic label for blog updates
+    conditions:
+      - "files~=^apps/blog/"
+    actions:
+      label:
+        add: ["app:blog"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm build -F "./packages/*"
-      - name: Create Changesets PR or Publish to NPM
+      - name: Create Version PR or Publish to NPM
         id: changesets
         uses: changesets/action@v1.4.10
         with:
@@ -41,10 +41,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_ENV: "production"
-      - name: Enable auto-merge for Changesets PRs
-        if: steps.changesets.outputs.hasChangesets
-        run: gh pr --repo "$REPO" merge --auto --merge "$PR_NUM"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUM: ${{ steps.changesets.outputs.pullRequestNumber }}
-          REPO: ${{ github.repository }}


### PR DESCRIPTION
Revert changes made to the auto-merge configuration for Dependabot and the rules for labeling blog updates. This ensures the previous settings are restored.