### PR TITLE
Improve AES-GCM encryption IV allocation and random value generation

### DIFF
--- a/apps/blog/lib/aes-gcm.ts
+++ b/apps/blog/lib/aes-gcm.ts
@@ -6,17 +6,16 @@ export async function encrypt(plaintext: string, password: string) {
   const pwUtf8 = new TextEncoder().encode(password);
   const pwHash = await subtle.digest("SHA-256", pwUtf8);
 
-  const iv = getRandomValues(new Uint8Array(12));
+  // Since `getRandomValues` fills the buffer with random bytes,
+  // we use `Buffer.allocUnsafe` to allocate RAM directly.
+  const iv = getRandomValues(Buffer.allocUnsafe(12));
   const alg = { name: "AES-GCM", iv };
   const key = await subtle.importKey("raw", pwHash, alg, false, ["encrypt"]);
 
   const ptUint8 = new TextEncoder().encode(plaintext);
   const ctBuffer = await subtle.encrypt(alg, key, ptUint8);
 
-  const ivHex = Buffer.from(iv).toString("hex");
-  const ctBase64 = Buffer.from(ctBuffer).toString("base64");
-
-  return ivHex + ctBase64;
+  return iv.toString("hex") + Buffer.from(ctBuffer).toString("base64");
 }
 
 export async function decrypt(ciphertext: string, password: string) {

--- a/apps/blog/lib/aes-gcm.ts
+++ b/apps/blog/lib/aes-gcm.ts
@@ -1,14 +1,14 @@
 import { Buffer } from "node:buffer";
-import { getRandomValues, subtle } from "node:crypto";
+import { subtle, webcrypto } from "node:crypto";
 import { TextDecoder, TextEncoder } from "node:util";
 
 export async function encrypt(plaintext: string, password: string) {
   const pwUtf8 = new TextEncoder().encode(password);
   const pwHash = await subtle.digest("SHA-256", pwUtf8);
 
-  // Since `getRandomValues` fills the buffer with random bytes,
+  // Since `webcrypto.getRandomValues` fills the buffer with random bytes,
   // we use `Buffer.allocUnsafe` to allocate RAM directly.
-  const iv = getRandomValues(Buffer.allocUnsafe(12));
+  const iv = webcrypto.getRandomValues(Buffer.allocUnsafe(12));
   const alg = { name: "AES-GCM", iv };
   const key = await subtle.importKey("raw", pwHash, alg, false, ["encrypt"]);
 


### PR DESCRIPTION
Use `Buffer.allocUnsafe` for IV allocation and update the import for `getRandomValues` to utilize `webcrypto` in AES-GCM encryption.