### PR TITLE
Refactor Author component to remove user_id prop

### DIFF
--- a/apps/blog/app/posts/[...ids]/page.tsx
+++ b/apps/blog/app/posts/[...ids]/page.tsx
@@ -85,7 +85,7 @@ const Page: NextPage<Props> = async ({ params }) => {
           // In order to optimize Cumulative Layout Shift (CLS)
           fallback={<Loading className="h-2" />}
         >
-          <Author page={parent} user_id={page.created_by.id /* Long ID */} />
+          <Author page={parent} />
         </Suspense>
       </section>
       <Separator className="mt-1 mb-3" />

--- a/apps/blog/app/posts/[id]/page.tsx
+++ b/apps/blog/app/posts/[id]/page.tsx
@@ -75,7 +75,7 @@ const Page: NextPage<Props> = async ({ params }) => {
           // In order to optimize Cumulative Layout Shift (CLS)
           fallback={<Loading className="h-2" />}
         >
-          <Author page={page} user_id={page.created_by.id /* Long ID */} />
+          <Author page={page} />
         </Suspense>
       </section>
       <Separator className="mt-1 mb-3" />

--- a/apps/blog/components/article-author.tsx
+++ b/apps/blog/components/article-author.tsx
@@ -3,12 +3,13 @@ import type { PageObjectResponse } from "@/lib/api-endpoints";
 import { notion } from "@/lib/notion";
 import { intlFormat } from "date-fns";
 
-type AuthorProps = { user_id: string; page: PageObjectResponse };
+type AuthorProps = { page: PageObjectResponse };
 
-export const Author: React.FC<AuthorProps> = async ({ user_id, page }) => {
+export const Author: React.FC<AuthorProps> = async ({ page }) => {
+  const user_id = page.created_by.id /* Long ID */;
   const { avatar_url, name } = await notion.users.retrieve({ user_id });
   const date = page.properties["Publish Date"];
-  const publidhDate = date.type === "date" && date.date?.start;
+  const publidhDate = date.type === "date" ? date.date?.start : null;
 
   return (
     <div className="flex justify-start items-center">
@@ -22,7 +23,7 @@ export const Author: React.FC<AuthorProps> = async ({ user_id, page }) => {
       )}
       <div>
         <p>{name ?? "Anonymous"}</p>
-        <p>{publidhDate && intlFormat(publidhDate)}</p>
+        <p>{intlFormat(publidhDate ?? page.created_time)}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Simplify the Author component by eliminating the user_id prop, retrieving the user_id directly from the page object instead. This enhances code clarity and reduces prop drilling.