### PR TITLE
Add error handling for image loading and update package manager version

### DIFF
--- a/.changeset/major-carpets-push.md
+++ b/.changeset/major-carpets-push.md
@@ -1,0 +1,9 @@
+---
+"@mogeko/blog": patch
+---
+
+Add error handling for image loading.
+
+Since the Cloudinary CDN is not always available in China, we use ImageKitas a fallback. The image is stored in Cloudinary and proxied through ImageKit.
+
+See: https://imagekit.io/docs/integration/web-proxy

--- a/apps/blog/components/image.tsx
+++ b/apps/blog/components/image.tsx
@@ -3,7 +3,7 @@ import { subtle } from "node:crypto";
 import { parse } from "node:path";
 import { URL } from "node:url";
 import { TextEncoder } from "node:util";
-import { cloudinaryLoader } from "@/lib/image-loader";
+import { cloudinaryLoader, handleError } from "@/lib/image-loader";
 import { v2 as cloudinary } from "cloudinary";
 import { unstable_cache as cache } from "next/cache";
 import NextImage from "next/image";
@@ -27,6 +27,7 @@ export const Image: React.FC<
       loader={cloudinaryLoader}
       src={public_id}
       alt={alt.length ? alt : fileName}
+      onError={handleError}
       {...props}
     />
   );

--- a/apps/blog/lib/image-loader.ts
+++ b/apps/blog/lib/image-loader.ts
@@ -10,3 +10,12 @@ export const cloudinaryLoader: ImageLoader = ({ src, width, quality }) => {
 
   return `${CLOUDINARY_BASE_URL}/${params.join(",")}/${src}`;
 };
+
+export function handleError(e: React.SyntheticEvent<HTMLImageElement, Event>) {
+  const target = e.target as HTMLImageElement;
+
+  // Since the Cloudinary CDN is not always available in China, we use ImageKit
+  // as a fallback. The image is stored in Cloudinary and proxied through ImageKit.
+  target.src = `https://ik.imagekit.io/mogeko/${target.src}`;
+  target.onerror = null; // prevents looping
+}

--- a/apps/blog/lib/image-loader.ts
+++ b/apps/blog/lib/image-loader.ts
@@ -16,6 +16,10 @@ export function handleError(e: React.SyntheticEvent<HTMLImageElement, Event>) {
 
   // Since the Cloudinary CDN is not always available in China, we use ImageKit
   // as a fallback. The image is stored in Cloudinary and proxied through ImageKit.
-  target.src = `https://ik.imagekit.io/mogeko/${target.src}`;
+  // See: https://imagekit.io/docs/integration/web-proxy
+  if (target.src.startsWith(CLOUDINARY_BASE_URL)) {
+    target.src = `https://ik.imagekit.io/mogeko/${target.src}`;
+  }
+
   target.onerror = null; // prevents looping
 }

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "**.notionusercontent.com" },
       { protocol: "https", hostname: "**.amazonaws.com" },
       { protocol: "https", hostname: "res.cloudinary.com/mogeko/image/upload" },
+      { protocol: "https", hostname: "ik.imagekit.io/mogeko" },
     ],
   },
   logging: {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "turbo": "^2.5.0",
     "vite-node": "^3.1.2"
   },
-  "packageManager": "pnpm@10.9.0",
+  "packageManager": "pnpm@10.10.0",
   "engines": {
     "node": ">=20.1.0"
   }


### PR DESCRIPTION
Implement error handling for image loading to fallback to ImageKit when Cloudinary fails. Update the package manager version to the latest.